### PR TITLE
Support Other Data Types

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -68,10 +68,10 @@ export type ClientToStorage = {
   broadcastChanges(): Promise<{ broadcastChanges: boolean }>;
   getItem(options: {
     key: string;
-  }): Promise<{ value: string } | StorageError | void>;
+  }): Promise<{ value: any } | StorageError | void>;
   setItem(options: {
     key: string;
-    value: string;
+    value: any;
   }): Promise<StorageError | void>;
   removeItem(options: { key: string }): Promise<StorageError | void>;
   clear(): Promise<StorageError | void>;

--- a/src/originStorage.ts
+++ b/src/originStorage.ts
@@ -66,7 +66,7 @@ export class OriginStorage
       return { error: NoReadAccessError };
     }
     try {
-      const value = (await this._localforage.getItem(options.key)) as string;
+      const value = (await this._localforage.getItem(options.key)) as any;
       return { value };
     } catch (e: any) {
       if (typeof e?.toString === 'function') {
@@ -79,7 +79,7 @@ export class OriginStorage
   }
 
   @listen
-  async setItem(options: { key: string; value: string }) {
+  async setItem(options: { key: string; value: any }) {
     if (!this._write) {
       if (__DEV__) {
         console.error(NoWriteAccessError);

--- a/src/originStorageClient.ts
+++ b/src/originStorageClient.ts
@@ -80,30 +80,15 @@ export class OriginStorageClient
     if ((result as StorageError)?.error) {
       throw new Error(`'getItem' error: ${(result as StorageError).error}`);
     }
-    let parsedValue: unknown;
-    const { value } = result as { value?: string };
-    if (value === null || typeof value === 'undefined') return null;
-    try {
-      parsedValue = JSON.parse(value as string);
-    } catch (e) {
-      console.error(`'getItem' JSON.parse Error`);
-      throw e;
-    }
-    return parsedValue;
+    const { value } = result as { value: any }
+    return value;
   }
 
   async setItem<T>(key: string, value: unknown) {
     if (!this._isConnect) {
       throw new Error(NoConnectError);
     }
-    let stringifiedValue: string;
-    try {
-      stringifiedValue = JSON.stringify(value);
-    } catch (e) {
-      console.error(`'setItem' JSON.stringify Error`);
-      throw e;
-    }
-    const result = await this.emit('setItem', { key, value: stringifiedValue });
+    const result = await this.emit('setItem', { key, value });
     if ((result as StorageError)?.error) {
       throw new Error(`'setItem' error: ${(result as StorageError).error}`);
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,7 +7,7 @@ class MemoryStorage {
   private _data: Record<string, any> = {};
 
   getItem(key: string) {
-    return this._data[key];
+    return this._data[key] || null;
   }
 
   setItem(key: string, value: any) {


### PR DESCRIPTION
Changes `getItem` and `setItem` to support any data type for values, instead of only strings, like localforage. Also localstorage returns `null` when there's no value - never `undefined` - so update the MemoryStorage mock to reflect this.

fixes #21